### PR TITLE
Check for Discord snap ipc file

### DIFF
--- a/pypresence/baseclient.py
+++ b/pypresence/baseclient.py
@@ -17,7 +17,7 @@ class BaseClient:
 
         client_id = str(client_id)
         if sys.platform == 'linux' or sys.platform == 'darwin':
-            self.ipc_path = (
+            base_path = (
                                     os.environ.get(
                                         'XDG_RUNTIME_DIR',
                                         None) or os.environ.get(
@@ -26,7 +26,10 @@ class BaseClient:
                                 'TMP',
                                 None) or os.environ.get(
                                 'TEMP',
-                                None) or '/tmp') + '/discord-ipc-' + str(pipe)
+                                None) or '/tmp')
+            snap_path = '/snap.discord'
+            base_path += snap_path if os.path.isdir(base_path + snap_path) else ''
+            self.ipc_path = base_path + '/discord-ipc-' + str(pipe)
             self.loop = asyncio.get_event_loop()
         elif sys.platform == 'win32':
             self.ipc_path = r'\\?\pipe\discord-ipc-' + str(pipe)

--- a/pypresence/baseclient.py
+++ b/pypresence/baseclient.py
@@ -27,9 +27,9 @@ class BaseClient:
                                 None) or os.environ.get(
                                 'TEMP',
                                 None) or '/tmp')
-            snap_path = '/snap.discord'
-            base_path += snap_path if os.path.isdir(base_path + snap_path) else ''
-            self.ipc_path = base_path + '/discord-ipc-' + str(pipe)
+            pipe_file = '/discord-ipc-' + str(pipe)
+            snap_path = base_path + '/snap.discord' + pipe_file
+            self.ipc_path = snap_path if os.path.exists(snap_path) else base_path + pipe_file
             self.loop = asyncio.get_event_loop()
         elif sys.platform == 'win32':
             self.ipc_path = r'\\?\pipe\discord-ipc-' + str(pipe)


### PR DESCRIPTION
I installed Discord from a [snap package](https://snapcraft.io/discord), so the ipc file path was a little different and I would get a FileNotFound error when trying to connect, same error as #24 

I added a simple little if else in BaseClient to check for the snap's ipc file and use it if it exists. :)