### PR TITLE
PyPI packaging improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ nyaaa/
 venv/
 __pycache__/
 test.py
+.mypy_cache/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
+[bdist_wheel]
+universal = 1
+
 [metadata]
 description-file = README.md
+license_file = LICENSE
+
+[aliases]
+release = sdist bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,46 @@
 from setuptools import setup
 
+# Use README for the PyPI page
+with open('README.md') as f:
+    long_description = f.read()
+
+# https://setuptools.readthedocs.io/en/latest/setuptools.html
 setup(name='pypresence',
       author='qwertyquerty',
       url='https://github.com/qwertyquerty/pypresence',
       version='3.0.0',
       packages=['pypresence'],
+      python_requires='>=3.5',
+      platforms=['Windows', 'Linux', 'OSX'],
+      zip_safe=True,
       license='MIT',
-      description='Discord RPC client written in python',
-	  long_description="A Discord RPC library in python! Wow! Looks like you've come to the right place. Just looking to do Rich Presence? We Got you covered."
+      description='Discord RPC client written in Python',
+      long_description=long_description,
+      # PEP 566, PyPI Warehouse, setuptools>=38.6.0 make markdown possible
+      long_description_content_type='text/markdown',
+      keywords='discord rich presence pypresence rpc gamers chat irc',
+
+      # Used by PyPI to classify the project and make it searchable
+      # Full list: https://pypi.org/pypi?%3Aaction=list_classifiers
+      classifiers=[
+            'Development Status :: 5 - Production/Stable',
+            'License :: OSI Approved :: MIT License',
+
+            'Operating System :: Microsoft :: Windows',
+            'Operating System :: POSIX :: Linux',
+            'Operating System :: MacOS :: MacOS X',
+
+            'Programming Language :: Python',
+            'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3 :: Only',
+            'Programming Language :: Python :: Implementation :: CPython',
+
+            'Intended Audience :: Developers',
+            'Topic :: Software Development :: Libraries :: Python Modules',
+            'Topic :: Software Development :: Libraries',
+            'Topic :: Communications :: Chat',
+            'Framework :: AsyncIO',
+      ]
 )


### PR DESCRIPTION
Improved the setuptools packaging that's used by PyPI (which is where most people will be installing from with `pip install pypresence`).

Summary
* Changed the description to be the full README contents
* Added classifiers and keywords to improve discoverability
* Added python_requires to help pip PEP 440)
* Added zip_safe flag since we're not accessing distributed files or anything
* Added LICENSE to package metadata
* Ensure universal wheels are always generated (better compatibility)
* Add a shorthand to cut a release (`python setup.py release`)

To publish a release:
```bash
python setup.py release
twine upload dist/*
```