### PR TITLE
Use a more widely accepted syntax for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,25 +62,25 @@ Creates the class ready for usage.
 
 ----------
 
-### `Presence.connect()`
+### `Presence#connect()`
 
 Initializes the connection - must be done in order to make any updates to Rich Presence.
 
 ----------
 
-### `Presence.clear(pid=os.getpid())`
+### `Presence#clear(pid=os.getpid())`
 
 Clear the presence.
 
 ----------
 
-### `Presence.close()`
+### `Presence#close()`
 
 Closes the connection.
 
 ----------
 
-### `Presence.update(**options)`
+### `Presence#update(**options)`
 
 Sets the user's presence on Discord. Takes the following as parameters.
 
@@ -113,19 +113,19 @@ Construct the Client.
 
 ----------
 
-### `Client.start()`
+### `Client#start()`
 
 Initializes the connection - must be done in order to run RPC commands.
 
 ----------
 
-### `Client.close()`
+### `Client#close()`
 
 Closes the connection.
 
 ----------
 
-### `Client.authorize(client_id, scopes, rpc_token=None, username=None)`
+### `Client#authorize(client_id, scopes, rpc_token=None, username=None)`
 
 Used to authenticate a new client with your app. By default this pops up a modal in-app that asks the user to authorize access to your app.
 
@@ -138,7 +138,7 @@ All the different scopes can be found here: [https://discordapp.com/developers/d
 
 ----------
 
-### `Client.authenticate(token)`
+### `Client#authenticate(token)`
 
 Used to authenticate an existing client with your app.
 
@@ -146,13 +146,13 @@ Used to authenticate an existing client with your app.
 
 ----------
 
-### `Client.get_guilds()`
+### `Client#get_guilds()`
 
 Used to get a list of guilds the client is in.
 
 ----------
 
-### `Client.get_guild(guild_id)`
+### `Client#get_guild(guild_id)`
 
 Used to get a guild the client is in.
 
@@ -160,7 +160,7 @@ Used to get a guild the client is in.
 
 ----------
 
-### `Client.get_channels(guild_id)`
+### `Client#get_channels(guild_id)`
 
 Used to get a guild's channels the client is in.
 
@@ -168,7 +168,7 @@ Used to get a guild's channels the client is in.
 
 ----------
 
-### `Client.get_channel(channel_id)`
+### `Client#get_channel(channel_id)`
 
 Used to get a channel the client is in.
 
@@ -176,7 +176,7 @@ Used to get a channel the client is in.
 
 ----------
 
-### `Client.set_user_voice_settings(user_id, pan_left=None, pan_right=None, volume=None, mute=None)`
+### `Client#set_user_voice_settings(user_id, pan_left=None, pan_right=None, volume=None, mute=None)`
 
 Used to change voice settings of users in voice channels.
 
@@ -188,7 +188,7 @@ Used to change voice settings of users in voice channels.
 
 ----------
 
-### `Client.select_voice_channel(channel_id)`
+### `Client#select_voice_channel(channel_id)`
 
 Used to join and leave voice channels, group dms, or dms.
 
@@ -196,13 +196,13 @@ Used to join and leave voice channels, group dms, or dms.
 
 ----------
 
-### `Client.get_selected_voice_channel()`
+### `Client#get_selected_voice_channel()`
 
 Used to get the client's current voice channel.
 
 ----------
 
-### `Client.select_text_channel(channel_id)`
+### `Client#select_text_channel(channel_id)`
 
 Used to join and leave text channels, group dms, or dms.
 
@@ -210,7 +210,7 @@ Used to join and leave text channels, group dms, or dms.
 
 ----------
 
-### `Client.set_activity(**options)`
+### `Client#set_activity(**options)`
 
 Used to set the activity shown on Discord profiles and status of users. Takes the following as parameters.
 
@@ -232,13 +232,13 @@ Used to set the activity shown on Discord profiles and status of users. Takes th
 
 ----------
 
-### `Client.clear_activity(pid=os.getpid())`
+### `Client#clear_activity(pid=os.getpid())`
 
 Clear the activity.
 
 ----------
 
-### `Client.subscribe(event,args={})`
+### `Client#subscribe(event,args={})`
 
 Used to subscribe to events.
 
@@ -247,7 +247,7 @@ Used to subscribe to events.
 
 ----------
 
-### `Client.unsubscribe(event,args={})`
+### `Client#unsubscribe(event,args={})`
 
 Used to unsubscribe from events.
 
@@ -256,13 +256,13 @@ Used to unsubscribe from events.
 
 ----------
 
-### `Client.get_voice_settings()`
+### `Client#get_voice_settings()`
 
 Get the user's voice settings.
 
 ----------
 
-### `Client.set_voice_settings(self, _input=None, output=None, mode=None, automatic_gain_control=None, echo_cancellation=None, noise_suppression=None, qos=None, silence_warning=None, deaf=None, mute=None)`
+### `Client#set_voice_settings(self, _input=None, output=None, mode=None, automatic_gain_control=None, echo_cancellation=None, noise_suppression=None, qos=None, silence_warning=None, deaf=None, mute=None)`
 
 Set the user's voice settings.
 
@@ -279,7 +279,7 @@ Set the user's voice settings.
 
 ----------
 
-### `Client.capture_shortcut(action)`
+### `Client#capture_shortcut(action)`
 
 Used to capture a keyboard shortcut entered by the user.
 
@@ -287,7 +287,7 @@ Used to capture a keyboard shortcut entered by the user.
 
 ----------
 
-### `Client.send_activity_join_invite(user_id)`
+### `Client#send_activity_join_invite(user_id)`
 
 Used to accept an Ask to Join request.
 
@@ -295,7 +295,7 @@ Used to accept an Ask to Join request.
 
 ----------
 
-### `Client.close_activity_request(user_id)`
+### `Client#close_activity_request(user_id)`
 
 Used to reject an Ask to Join request.
 
@@ -305,7 +305,7 @@ Used to reject an Ask to Join request.
 
 ## Events
 
-### `Client.register_event(event, func, args={})`
+### `Client#register_event(event, func, args={})`
 
 Hook an event to a function. The function will be called whenever Discord sends that event. Will auto subscribe to it.
 
@@ -315,7 +315,7 @@ Hook an event to a function. The function will be called whenever Discord sends 
 
 ----------
 
-### `Client.unregister_event(event, args={})`
+### `Client#unregister_event(event, args={})`
 
 Unhook an event from a function. Will auto unsubscribe from the event as well.
 


### PR DESCRIPTION
Generally, people use `Instance#method` for instances of a class/object.