### PR TITLE
Fixing pipe file typo

### DIFF
--- a/pypresence/baseclient.py
+++ b/pypresence/baseclient.py
@@ -24,7 +24,7 @@ class BaseClient:
         if sys.platform == 'linux' or sys.platform == 'darwin':
             tempdir = (os.environ.get('XDG_RUNTIME_DIR') or tempfile.gettempdir())
             snap_path = '{0}/snap.discord'.format(tempdir)
-            pipe_file = 'discord-ipc-{0}'.fomrat(pipe)
+            pipe_file = 'discord-ipc-{0}'.format(pipe)
             if os.path.isdir(snap_path):
                 self.ipc_path = '{0}/{1}'.format(snap_path, pipe_file)
             else:


### PR DESCRIPTION
**WHAT**
Fixing typo on pipe_file definition

**TEST**
Manually created new presences and ran `tox`