### PR TITLE
If the global loop is closed, just open a fresh one

### DIFF
--- a/pypresence/baseclient.py
+++ b/pypresence/baseclient.py
@@ -29,15 +29,13 @@ class BaseClient:
                 self.ipc_path = '{0}/{1}'.format(snap_path, pipe_file)
             else:
                 self.ipc_path = '{0}/{1}'.format(tempdir, pipe_file)
-            if asyncio.get_event_loop().is_closed():
-                asyncio.set_event_loop(asyncio.new_event_loop())
-            self.loop = asyncio.get_event_loop()
         elif sys.platform == 'win32':
             self.ipc_path = r'\\?\pipe\discord-ipc-' + str(pipe)
-            self.loop = asyncio.ProactorEventLoop()
 
         if loop is not None:
-            self.loop = loop
+            self.update_event_loop(loop)
+        else:
+            self.update_event_loop(self.get_platform_specific_event_loop())
 
         self.sock_reader = None  # type: asyncio.StreamReader
         self.sock_writer = None  # type: asyncio.StreamWriter
@@ -68,6 +66,26 @@ class BaseClient:
             self._events_on = True
         else:
             self._events_on = False
+
+    def get_platform_specific_event_loop(self, force_fresh=False):
+        if sys.platform == 'linux' or sys.platform == 'darwin':
+            if force_fresh:
+                return asyncio.new_event_loop()
+            loop = asyncio.get_event_loop()
+            if loop.is_closed():
+                return asyncio.new_event_loop()
+            return loop
+        elif sys.platform == 'win32':
+            if force_fresh:
+                return asyncio.ProactorEventLoop()
+            loop = asyncio.get_event_loop()
+            if isinstance(loop, asyncio.ProactorEventLoop) and not loop.is_closed():
+                return loop
+            return asyncio.ProactorEventLoop()
+
+    def update_event_loop(self, loop):
+        self.loop = loop
+        asyncio.set_event_loop(self.loop)
 
     def _err_handle(self, loop, context: dict):
         result = self.handler(context['exception'], context['future'])

--- a/pypresence/baseclient.py
+++ b/pypresence/baseclient.py
@@ -29,6 +29,8 @@ class BaseClient:
                 self.ipc_path = '{0}/{1}'.format(snap_path, pipe_file)
             else:
                 self.ipc_path = '{0}/{1}'.format(tempdir, pipe_file)
+            if asyncio.get_event_loop().is_closed():
+                asyncio.set_event_loop(asyncio.new_event_loop())
             self.loop = asyncio.get_event_loop()
         elif sys.platform == 'win32':
             self.ipc_path = r'\\?\pipe\discord-ipc-' + str(pipe)

--- a/pypresence/baseclient.py
+++ b/pypresence/baseclient.py
@@ -35,7 +35,7 @@ class BaseClient:
         if loop is not None:
             self.update_event_loop(loop)
         else:
-            self.update_event_loop(self.get_platform_specific_event_loop())
+            self.update_event_loop(self.get_event_loop())
 
         self.sock_reader = None  # type: asyncio.StreamReader
         self.sock_writer = None  # type: asyncio.StreamWriter
@@ -67,7 +67,7 @@ class BaseClient:
         else:
             self._events_on = False
 
-    def get_platform_specific_event_loop(self, force_fresh=False):
+    def get_event_loop(self, force_fresh=False):
         if sys.platform == 'linux' or sys.platform == 'darwin':
             if force_fresh:
                 return asyncio.new_event_loop()

--- a/pypresence/presence.py
+++ b/pypresence/presence.py
@@ -37,6 +37,7 @@ class Presence(BaseClient):
         return self.loop.run_until_complete(self.read_output())
 
     def connect(self):
+        self.update_event_loop(self.get_platform_specific_event_loop())
         self.loop.run_until_complete(self.handshake())
 
     def close(self):
@@ -70,6 +71,7 @@ class AioPresence(BaseClient):
         return await self.read_output()
 
     async def connect(self):
+        self.update_event_loop(self.get_platform_specific_event_loop())
         await self.handshake()
 
     def close(self):

--- a/pypresence/presence.py
+++ b/pypresence/presence.py
@@ -37,7 +37,7 @@ class Presence(BaseClient):
         return self.loop.run_until_complete(self.read_output())
 
     def connect(self):
-        self.update_event_loop(self.get_platform_specific_event_loop())
+        self.update_event_loop(self.get_event_loop())
         self.loop.run_until_complete(self.handshake())
 
     def close(self):
@@ -71,7 +71,7 @@ class AioPresence(BaseClient):
         return await self.read_output()
 
     async def connect(self):
-        self.update_event_loop(self.get_platform_specific_event_loop())
+        self.update_event_loop(self.get_event_loop())
         await self.handshake()
 
     def close(self):


### PR DESCRIPTION
When .close() was being called on a Presence object, if you did not provide your own loop, the global loop was being closed, with no way to reopen it.  This corrects that by ensuring that if the global loop is already closed, we just open a new one.

My contribution does pass tests, but there are other ones in the repo which don't pass.  I may take some time to clean those up, but as this is a bug fix, I think it's worthy of pushing through without work that's out of the scope of my change.