### PR TITLE
Fix that select_text_channel selects voice channels.

### DIFF
--- a/pypresence/payloads.py
+++ b/pypresence/payloads.py
@@ -198,7 +198,7 @@ class Payload:
     @classmethod
     def select_text_channel(cls, channel_id: str):
         payload = {
-            "cmd": "SELECT_VOICE_CHANNEL",
+            "cmd": "SELECT_TEXT_CHANNEL",
             "args": {
                 "channel_id": str(channel_id),
             },


### PR DESCRIPTION
`select_text_channel` used `SELECT_VOICE_CHANNEL` as cmd in the payload instead of `SELECT_TEXT_CHANNEL`.