### PR TITLE
baseclient: fix for sock_reader reads using fixed 1024 buffer length

### DIFF
--- a/pypresence/baseclient.py
+++ b/pypresence/baseclient.py
@@ -99,11 +99,12 @@ class BaseClient:
 
     async def read_output(self):
         try:
-            data = await self.sock_reader.read(1024)
+            preamble = await self.sock_reader.read(8)
+            status_code, length = struct.unpack('<II', preamble[:8])
+            data = await self.sock_reader.read(length)
         except BrokenPipeError:
             raise InvalidID
-        status_code, length = struct.unpack('<II', data[:8])
-        payload = json.loads(data[8:].decode('utf-8'))
+        payload = json.loads(data.decode('utf-8'))
         if payload["evt"] == "ERROR":
             raise ServerError(payload["data"]["message"])
         return payload
@@ -131,7 +132,8 @@ class BaseClient:
             except FileNotFoundError:
                 raise InvalidPipe
         self.send_data(0, {'v': 1, 'client_id': self.client_id})
-        data = await self.sock_reader.read(1024)
-        code, length = struct.unpack('<ii', data[:8])
+        preamble = await self.sock_reader.read(8)
+        code, length = struct.unpack('<ii', preamble)
+        data = await self.sock_reader.read(length)
         if self._events_on:
             self.sock_reader.feed_data = self.on_event


### PR DESCRIPTION
### What this fixes

The JSON module fails to decode the response returned by some endpoints when the response length is past a certain size.

### How it fixes it

The calls to `sock_reader.read` made in the `BaseClient` class use a fixed buffer size of 1024 bytes. Although the expected response length is retrieved, it is not used to make a read of the appropriate size.

This is easily fixed by first reading independently the 8 bytes for the status code and response length, and then using this response length as the buffer size in a new `sock_reader.read` call.

### Sample traceback

```
Traceback (most recent call last):
  File "test.py", line 42, in <module>
    print(RPC.get_guilds())
  File "/home/frazew/.local/lib/python3.8/site-packages/pypresence/client.py", line 71, in get_guilds
    return self.loop.run_until_complete(self.read_output())
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/home/frazew/.local/lib/python3.8/site-packages/pypresence/baseclient.py", line 103, in read_output
    payload = json.loads(data[8:].decode('utf-8'))
  File "/usr/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.8/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.8/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Unterminated string starting at: line 1 column 1007 (char 1006)
```