### PR TITLE
Handle synchronous on_event correctly

### DIFF
--- a/pypresence/client.py
+++ b/pypresence/client.py
@@ -50,13 +50,11 @@ class Client(BaseClient):
         end = 0
         chunks = []
         while end < len(data):
+            # While chunks are available in data
             start = end+8
             status_code, length=struct.unpack('<II',data[end:start])
             end = length+start
-            chunks.append(data[start:end].decode('utf-8'))
-        
-        for chunk in chunks:
-            payload = json.loads(chunk)
+            payload = json.loads(data[start:end].decode('utf-8'))
 
             if payload["evt"] is not None:
                 evt = payload["evt"].lower()

--- a/pypresence/client.py
+++ b/pypresence/client.py
@@ -47,12 +47,13 @@ class Client(BaseClient):
             else:
                 self.sock_reader._paused = True
         
-        length = 0
+        end = 0
         chunks = []
-        while length+8 < len(data):
-            start = length+8
-            status_code, length=struct.unpack('<II',data[length:start])
-            chunks.append(data[start:start+length].decode('utf-8'))
+        while end < len(data):
+            start = end+8
+            status_code, length=struct.unpack('<II',data[end:start])
+            end = length+start
+            chunks.append(data[start:end].decode('utf-8'))
         
         for chunk in chunks:
             payload = json.loads(chunk)

--- a/pypresence/client.py
+++ b/pypresence/client.py
@@ -48,7 +48,6 @@ class Client(BaseClient):
                 self.sock_reader._paused = True
         
         end = 0
-        chunks = []
         while end < len(data):
             # While chunks are available in data
             start = end+8


### PR DESCRIPTION
Sometimes the reader would get a bit excitable and read ahead of what it's supposed to, causing either the JSON or Unicode decoding process to break. 

This PR breaks the data back down into chunks using the data frame, and reads it payload by payload to the event listeners.