### PR TITLE
Create full-event-client-example.py

### DIFF
--- a/examples/full-event-client-example.py
+++ b/examples/full-event-client-example.py
@@ -3,15 +3,14 @@ import pypresence
 
 CLIENT_ID = 555555555555555555
 
-def message_created(data):
-    print("New message: %s" % data['message']['content'])
-
 loop = asyncio.get_event_loop()
-c = pypresence.Client(CLIENT_ID,loop=loop)
+c = pypresence.Client(CLIENT_ID, loop=loop)
 c.start()
-# Prompt user for authorization to do stuff
-auth = c.authorize(CLIENT_ID,['rpc'])
+
+# Prompt user for authorization to do stuff with RPC scopes
+auth = c.authorize(CLIENT_ID, ['rpc'])
 code_grant = auth['data']['code']
+
 '''
 Implement the API found here for code/token exchange: 
 https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-exchange-example
@@ -22,8 +21,11 @@ token = exchange_code(code_grant)
 # Now authenticate with the token we got (Save to skip authorization later)
 c.authenticate(token['access_token'])
 
+def on_new_message(data):
+    print("New message: %s" % data['message']['content'])
+
 # Watch for new messages created on channel 444444444444444444
-a = c.register_event('MESSAGE_CREATE',message_created,args={'channel_id':'444444444444444444'))
+c.register_event('MESSAGE_CREATE', on_new_message, args={'channel_id':'444444444444444444'))
 # Find other event types here: https://discord.com/developers/docs/topics/rpc#commands-and-events-rpc-events
 
 loop.run_forever()

--- a/examples/full-event-client-example.py
+++ b/examples/full-event-client-example.py
@@ -1,0 +1,29 @@
+import asyncio
+import pypresence
+
+CLIENT_ID = 555555555555555555
+
+def message_created(data):
+    print("New message: %s" % data['message']['content'])
+
+loop = asyncio.get_event_loop()
+c = pypresence.Client(CLIENT_ID,loop=loop)
+c.start()
+# Prompt user for authorization to do stuff
+auth = c.authorize(CLIENT_ID,['rpc'])
+code_grant = auth['data']['code']
+'''
+Implement the API found here for code/token exchange: 
+https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-exchange-example
+(NOTE: Redirect URI is needed and should be what's set in your Dev Application's OAuth2 screen)
+'''
+token = exchange_code(code_grant) 
+
+# Now authenticate with the token we got (Save to skip authorization later)
+c.authenticate(token['access_token'])
+
+# Watch for new messages created on channel 444444444444444444
+a = c.register_event('MESSAGE_CREATE',message_created,args={'channel_id':'444444444444444444'))
+# Find other event types here: https://discord.com/developers/docs/topics/rpc#commands-and-events-rpc-events
+
+loop.run_forever()


### PR DESCRIPTION
Lots of people wondering how to use events on Discord and in past issues with little examples given ever. This is a full example of using the client and how to listen for RPC events (as well as links to documentation for other event types)

If you think it being a full authorize/authenticate bit of code all but missing the exchange_code API is a bit redundant considering other examples, I'll be happy to simplify it for the specific case.  

Closes #88 