### PR TITLE
Improved IPC pipe discovery

### DIFF
--- a/pypresence/baseclient.py
+++ b/pypresence/baseclient.py
@@ -9,30 +9,19 @@ from typing import Union
 
 from .exceptions import *
 from .payloads import Payload
+from .utils import get_ipc_path
 
 
 class BaseClient:
 
     def __init__(self, client_id: str, **kwargs):
-        pipe = kwargs.get('pipe', 0)
+        pipe = kwargs.get('pipe', None)
         loop = kwargs.get('loop', None)
         handler = kwargs.get('handler', None)
         self.isasync = kwargs.get('isasync', False)
 
         client_id = str(client_id)
-        if sys.platform == 'linux' or sys.platform == 'darwin':
-            tempdir = (os.environ.get('XDG_RUNTIME_DIR') or tempfile.gettempdir())
-            snap_path = '{0}/snap.discord'.format(tempdir)
-            flatpak_path = '{0}/app/com.discordapp.Discord'.format(tempdir)
-            pipe_file = 'discord-ipc-{0}'.format(pipe)
-            if os.path.isdir(snap_path):
-                self.ipc_path = '{0}/{1}'.format(snap_path, pipe_file)
-            elif os.path.isdir(flatpak_path):
-                self.ipc_path = '{0}/{1}'.format(flatpak_path, pipe_file)
-            else:
-                self.ipc_path = '{0}/{1}'.format(tempdir, pipe_file)
-        elif sys.platform == 'win32':
-            self.ipc_path = r'\\?\pipe\discord-ipc-' + str(pipe)
+        self.ipc_path = get_ipc_path(pipe)
 
         if loop is not None:
             self.update_event_loop(loop)

--- a/pypresence/utils.py
+++ b/pypresence/utils.py
@@ -2,6 +2,8 @@
 import asyncio
 import json
 import time
+import os
+import sys
 
 from .exceptions import PyPresenceException
 
@@ -17,6 +19,29 @@ def remove_none(d: dict):
         elif d[item] is None:
             del d[item]
     return d
+
+
+# Returns on first IPC pipe matching Discord's
+def get_ipc_path(pipe=None):
+    ipc = 'discord-ipc-'
+    if pipe:
+        ipc = f"{ipc}{pipe}"
+
+    if sys.platform == 'linux' or sys.platform == 'darwin':
+        tempdir = (os.environ.get('XDG_RUNTIME_DIR') or tempfile.gettempdir())
+        paths = ['.','snap.discord','app/com.discordapp.Discord']
+    elif sys.platform == 'win32':
+        tempdir = r'\\?\pipe'
+        paths = ['.']
+    
+    for path in paths:
+        full_path = os.path.abspath(os.path.join(tempdir,path))
+        if sys.platform == 'win32' or os.path.isdir(full_path):
+            for entry in os.scandir(full_path):
+                if entry.name.startswith(ipc):
+                    return entry.path
+    
+    return None
 
 
 # Don't call these. Ever.


### PR DESCRIPTION
Not sure this is exactly how this wants to function, but this will scan all potential Linux paths (single-level -- not recursive) and the Windows "path" for a pipe entry that matches the starting format of `discord-ipc-`. If a pipe has been specified, then it will check for `discord-ipc-{pipe}`

On the *first entry* that it finds matching that format, it returns the full path which can then be used for IPC. This saves people needing to think too hard about pipes unless they want to.

This has been tested on Windows and Linux. 