### PR TITLE
Handle Discord errors on handshake

### DIFF
--- a/pypresence/baseclient.py
+++ b/pypresence/baseclient.py
@@ -137,7 +137,7 @@ class BaseClient:
         self.send_data(0, {'v': 1, 'client_id': self.client_id})
         preamble = await self.sock_reader.read(8)
         code, length = struct.unpack('<ii', preamble)
-        data = await self.sock_reader.read(length)
+        data = json.loads(await self.sock_reader.read(length))
         if 'code' in data:
             raise DiscordError(data['code'],data['message'])
         if self._events_on:

--- a/pypresence/baseclient.py
+++ b/pypresence/baseclient.py
@@ -138,5 +138,7 @@ class BaseClient:
         preamble = await self.sock_reader.read(8)
         code, length = struct.unpack('<ii', preamble)
         data = await self.sock_reader.read(length)
+        if 'code' in data:
+            raise DiscordError(data['code'],data['message'])
         if self._events_on:
             self.sock_reader.feed_data = self.on_event


### PR DESCRIPTION
Allows handling of Discord errors specifically like 'Logged out' and 'Invalid Client ID' on initial `connect()` call, rather than relying on 'BrokenPipeError' which seems to not work perfectly, and doesn't always give the correct details.