### PR TITLE
Return 'ready' event data on handshake

### DIFF
--- a/pypresence/client.py
+++ b/pypresence/client.py
@@ -193,7 +193,7 @@ class Client(BaseClient):
         self.loop.close()
 
     def start(self):
-        self.loop.run_until_complete(self.handshake())
+        return self.loop.run_until_complete(self.handshake())
 
     def read(self):
         return self.loop.run_until_complete(self.read_output())
@@ -374,7 +374,7 @@ class AioClient(BaseClient):
         self.loop.close()
 
     async def start(self):
-        await self.handshake()
+        return await self.handshake()
 
     async def read(self):
         return await self.read_output()

--- a/pypresence/presence.py
+++ b/pypresence/presence.py
@@ -42,7 +42,7 @@ class Presence(BaseClient):
 
     def connect(self):
         self.update_event_loop(get_event_loop())
-        self.loop.run_until_complete(self.handshake())
+        return self.loop.run_until_complete(self.handshake())
 
     def close(self):
         self.send_data(2, {'v': 1, 'client_id': self.client_id})
@@ -79,7 +79,7 @@ class AioPresence(BaseClient):
 
     async def connect(self):
         self.update_event_loop(get_event_loop())
-        await self.handshake()
+        return await self.handshake()
 
     def close(self):
         self.send_data(2, {'v': 1, 'client_id': self.client_id})


### PR DESCRIPTION
This allows developers to get the active Discord user's display info when using even just a regular presence by having all handshake calls return the 'ready' event data.

Example:
```python
from pypresence import Presence

CLIENT_ID = '555555555555555555'
RPC = Presence(CLIENT_ID)

ready_data = RPC.connect()
user = ready_data['user']

print(f"{user['username']}#{user['discriminator']} is the user: {user['id']}")
```

As a note, another option was to pass on the ready event to the 'on_event' function, but that seemed less elegant, as it would require bypassing the 'subscribe' model of `register_event()` in Client class. (you can't subscribe to 'ready' event, obvs) 
Additionally, as the Presence class doesn't have any `on_event` functionality, if users wanted to take advantage of it for a pure Rich Presence app, they'd have to either switch to Client or implement `on_event` themselves just to have user data.

Dealing with it this way seems the cleanest to me, but open to other suggestions.