### PR TITLE
Fix Fix select_voice_channel not disconnecting channel_id is None + add "force" parameter

### DIFF
--- a/pypresence/client.py
+++ b/pypresence/client.py
@@ -288,8 +288,8 @@ class AioClient(BaseClient):
         self.send_data(1, payload)
         return await self.read_output()
 
-    async def select_voice_channel(self, channel_id: str):
-        payload = Payload.select_voice_channel(channel_id)
+    async def select_voice_channel(self, channel_id: str, force: bool = False):
+        payload = Payload.select_voice_channel(channel_id, force)
         self.send_data(1, payload)
         return await self.read_output()
 

--- a/pypresence/client.py
+++ b/pypresence/client.py
@@ -104,8 +104,8 @@ class Client(BaseClient):
         self.send_data(1, payload)
         return self.loop.run_until_complete(self.read_output())
 
-    def select_voice_channel(self, channel_id: str):
-        payload = Payload.select_voice_channel(channel_id)
+    def select_voice_channel(self, channel_id: str, force: bool = False):
+        payload = Payload.select_voice_channel(channel_id, force)
         self.send_data(1, payload)
         return self.loop.run_until_complete(self.read_output())
 

--- a/pypresence/payloads.py
+++ b/pypresence/payloads.py
@@ -174,13 +174,14 @@ class Payload:
         return cls(payload, True)
 
     @classmethod
-    def select_voice_channel(cls, channel_id: str):
+    def select_voice_channel(cls, channel_id: str, force: bool):
         if channel_id is not None:
                 channel_id = str(channel_id)
         payload = {
             "cmd": "SELECT_VOICE_CHANNEL",
             "args": {
                 "channel_id": channel_id,
+                "force": force,
             },
             "nonce": '{:.20f}'.format(cls.time())
         }

--- a/pypresence/payloads.py
+++ b/pypresence/payloads.py
@@ -175,15 +175,17 @@ class Payload:
 
     @classmethod
     def select_voice_channel(cls, channel_id: str):
+        if channel_id is not None:
+                channel_id = str(channel_id)
         payload = {
             "cmd": "SELECT_VOICE_CHANNEL",
             "args": {
-                "channel_id": str(channel_id),
+                "channel_id": channel_id,
             },
             "nonce": '{:.20f}'.format(cls.time())
         }
 
-        return cls(payload)
+        return cls(payload, False)
 
     @classmethod
     def get_selected_voice_channel(cls):


### PR DESCRIPTION
Hi,
I have fixed a little issue with select_voice_channel:
When channel_id is None, the user is not disconnected and you have an error message that the user is allready connected to a voice channel. 

I have also added the "force" parameter that I mention on #122 