### PR TITLE
Add timeout for baseclient read_output

### DIFF
--- a/pypresence/exceptions.py
+++ b/pypresence/exceptions.py
@@ -5,6 +5,11 @@ class PyPresenceException(Exception):
         super().__init__(message)
 
 
+class TimeoutError(PyPresenceException):
+    def __init__(self, timeout):
+        super().__init__(f'Discord pipe did not respond within {timeout} seconds.')
+
+
 class DiscordNotFound(PyPresenceException):
     def __init__(self):
         super().__init__('Could not find Discord installed and running on this machine.')


### PR DESCRIPTION
This part of the code was blocking for me a couple weeks ago. I've set the timeout to 2 seconds but I'm not sure if that's ample enough.

Addition of this code should bump the major version of this library.