### PR TITLE
Update utils.py to include the Discord Canary flatpak

### DIFF
--- a/pypresence/utils.py
+++ b/pypresence/utils.py
@@ -30,7 +30,7 @@ def get_ipc_path(pipe=None):
 
     if sys.platform in ('linux', 'darwin'):
         tempdir = (os.environ.get('XDG_RUNTIME_DIR') or tempfile.gettempdir())
-        paths = ['.', 'snap.discord', 'app/com.discordapp.Discord']
+        paths = ['.', 'snap.discord', 'app/com.discordapp.Discord', 'app/com.discordapp.DiscordCanary']
     elif sys.platform == 'win32':
         tempdir = r'\\?\pipe'
         paths = ['.']


### PR DESCRIPTION
The Discord Canary uses  com.discordapp.DiscordCanary. This PR adds it to the search path