### PR TITLE
Allow running pypresence without `XDG_RUNTIME_DIR` env variable on Linux

### DIFF
--- a/pypresence/utils.py
+++ b/pypresence/utils.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import time
 
+from typing import Tuple, List
 from .exceptions import PyPresenceException
 
 
@@ -22,27 +23,55 @@ def remove_none(d: dict):
     return d
 
 
+def _get_probable_discord_path() -> Tuple[str | None, List[str]]:
+    """
+    Gets the probable locations for the Discord IPC to be located at.
+
+    Returns: Tuple with a possible pipe paths and a list of Discord ipc folder names
+    """
+    if sys.platform in ('linux', 'darwin'):
+        folder_names = ['.', 'snap.discord', 'app/com.discordapp.Discord']
+
+        xdg_runtime_dir = os.environ.get('XDG_RUNTIME_DIR') # Runtime dir set by GUI enviroment
+        users_runtime_dir = f"/run/user/{os.getuid()}" # Possible location for user's runtime
+
+        if xdg_runtime_dir:
+            return xdg_runtime_dir, folder_names
+
+        if os.path.exists(users_runtime_dir):
+            # Runtime directory check `/run/user/[UID]` as fix for #216
+            return users_runtime_dir, folder_names
+
+        return tempfile.gettempdir()
+
+    if sys.platform == 'win32':
+        pipe_dir = r'\\?\pipe'
+        folder_names = ['.']
+
+        return pipe_dir, application_names
+
+    return None, [] # No known Discord locations for used OS. Probably never gets here
+
+
 # Returns on first IPC pipe matching Discord's
 def get_ipc_path(pipe=None):
     ipc = 'discord-ipc-'
     if pipe:
         ipc = f"{ipc}{pipe}"
 
-    if sys.platform in ('linux', 'darwin'):
-        tempdir = (os.environ.get('XDG_RUNTIME_DIR') or tempfile.gettempdir())
-        paths = ['.', 'snap.discord', 'app/com.discordapp.Discord', 'app/com.discordapp.DiscordCanary']
-    elif sys.platform == 'win32':
-        tempdir = r'\\?\pipe'
-        paths = ['.']
-    else:
+    tmp_dir, folder_names = _get_probable_discord_path()
+    if (tmp_dir == None or len(folder_names) == 0):
         return
-    
-    for path in paths:
-        full_path = os.path.abspath(os.path.join(tempdir, path))
-        if sys.platform == 'win32' or os.path.isdir(full_path):
-            for entry in os.scandir(full_path):
-                if entry.name.startswith(ipc) and os.path.exists(entry):
-                    return entry.path
+
+    for folder in folder_names:
+        full_path = os.path.abspath(os.path.join(tmp_dir, folder))
+
+        if not (sys.platform == 'win32' or os.path.isdir(full_path)):
+            continue
+
+        for entry in os.scandir(full_path):
+            if entry.name.startswith(ipc) and os.path.exists(entry):
+                return entry.path
 
 
 def get_event_loop(force_fresh=False):

--- a/pypresence/utils.py
+++ b/pypresence/utils.py
@@ -32,7 +32,7 @@ def _get_probable_discord_path() -> Tuple[str | None, List[str]]:
     if sys.platform in ('linux', 'darwin'):
         folder_names = ['.', 'snap.discord', 'app/com.discordapp.Discord']
 
-        xdg_runtime_dir = os.environ.get('XDG_RUNTIME_DIR') # Runtime dir set by GUI enviroment
+        xdg_runtime_dir = os.environ.get('XDG_RUNTIME_DIR') # Runtime dir set by GUI environment
         users_runtime_dir = f"/run/user/{os.getuid()}" # Possible location for user's runtime
 
         if xdg_runtime_dir:
@@ -48,7 +48,7 @@ def _get_probable_discord_path() -> Tuple[str | None, List[str]]:
         pipe_dir = r'\\?\pipe'
         folder_names = ['.']
 
-        return pipe_dir, application_names
+        return pipe_dir, folder_names
 
     return None, [] # No known Discord locations for used OS. Probably never gets here
 
@@ -60,7 +60,7 @@ def get_ipc_path(pipe=None):
         ipc = f"{ipc}{pipe}"
 
     tmp_dir, folder_names = _get_probable_discord_path()
-    if (tmp_dir == None or len(folder_names) == 0):
+    if (tmp_dir is None or len(folder_names) == 0):
         return
 
     for folder in folder_names:


### PR DESCRIPTION
Added an additional check for Linux systems to be able to run without the `XDG_RUNTIME_DIR` enviroment variable. Added becouse not all enviroments, like cron, have those X runtime variables set without explicit definition. See issue linked below.

Resolves qwertyquerty/pypresence#216