### PR TITLE
Allow running pypresence without `XDG_RUNTIME_DIR` env variable on Linux

### DIFF
--- a/pypresence/utils.py
+++ b/pypresence/utils.py
@@ -29,8 +29,19 @@ def get_ipc_path(pipe=None):
         ipc = f"{ipc}{pipe}"
 
     if sys.platform in ('linux', 'darwin'):
-        tempdir = (os.environ.get('XDG_RUNTIME_DIR') or tempfile.gettempdir())
+        tempdir = os.environ.get('XDG_RUNTIME_DIR') # Runtime dir set by Linux GUI environment
         paths = ['.', 'snap.discord', 'app/com.discordapp.Discord', 'app/com.discordapp.DiscordCanary']
+        users_runtime_dir = f"/run/user/{os.getuid()}" # Possible location for Linux user's runtime
+
+        if tempdir:
+            pass # No overwrite needed, can probably trust the set XDG_RUNTIME_DIR variable
+        elif os.path.exists(users_runtime_dir):
+            # Runtime directory check as fix for #216
+            tempdir = users_runtime_dir
+        else:
+            tempdir = tempfile.gettempdir()
+
+        del users_runtime_dir
     elif sys.platform == 'win32':
         tempdir = r'\\?\pipe'
         paths = ['.']


### PR DESCRIPTION
Added an additional check for Linux systems to be able to run without the `XDG_RUNTIME_DIR` enviroment variable. Added becouse not all enviroments, like cron, have those X runtime variables set without explicit definition. See issue linked below.

Minimalized changes needed for pull request #217 with the path variables untouched. Same refactors as before are still available in Electrenator/pypresence@2539c1bdf0456a205a346ca0e1a785dd43cac2b8.

Resolves commit qwertyquerty/pypresence#216