### PR TITLE
Return ProactorEventLoop for windows

### DIFF
--- a/pypresence/utils.py
+++ b/pypresence/utils.py
@@ -53,4 +53,12 @@ def get_event_loop(force_fresh=False):
         return asyncio.new_event_loop()
     if running.is_closed():
         return asyncio.new_event_loop()
-    return running
+    else:
+        if sys.platform in ('linux', 'darwin'):
+            return running
+        if sys.platform == 'win32':
+            if isinstance(running, asyncio.ProactorEventLoop):
+                return running
+            else:
+                return asyncio.ProactorEventLoop()
+


### PR DESCRIPTION
In case where there is a running loop but  the loop is not Proactor Event loop.