### PR TITLE
Remove empty collections as well, because Discord does not allow empty strings

### DIFF
--- a/pypresence/utils.py
+++ b/pypresence/utils.py
@@ -18,6 +18,8 @@ def remove_none(d: dict):
                 del d[item]
         elif d[item] is None:
             del d[item]
+        elif not len(d[item]):
+            del d[item]
     return d
 
 

--- a/pypresence/utils.py
+++ b/pypresence/utils.py
@@ -18,7 +18,7 @@ def remove_none(d: dict):
                 del d[item]
         elif d[item] is None:
             del d[item]
-        elif not len(d[item]):
+        elif hasattr(d[item], "__len__") and not len(d[item]):
             del d[item]
     return d
 


### PR DESCRIPTION
Discord doesn't allow empty strings in presence fields. This PR resolves that issue by removing all empty collections in remove_none
