### PR TITLE
Fix `get_ipc_path()` when `pipe=0``

### DIFF
--- a/pypresence/utils.py
+++ b/pypresence/utils.py
@@ -24,7 +24,7 @@ def remove_none(d: dict):
 # Returns on first IPC pipe matching Discord's
 def get_ipc_path(pipe=None):
     ipc = 'discord-ipc-'
-    if pipe:
+    if pipe is not None:
         ipc = f"{ipc}{pipe}"
 
     if sys.platform in ('linux', 'darwin'):


### PR DESCRIPTION
Sometimes Discord creates multiple IPCs like `discord-ipc-0`, `discord-ipc-1` .
Current implementation found/used  `discord-ipc-1` which failed to connect.
And passing `pipe=0` also failed because it's considered Falsy and thus we still used same `'discord-ipc-'` pattern.
This PR makes  `pipe=0` work and correctly uses `discord-ipc-0`
