### PR TITLE
Fix windows rpc close & broken ipc pipe detection

### DIFF
--- a/pypresence/presence.py
+++ b/pypresence/presence.py
@@ -1,6 +1,7 @@
 import json
 import os
 import time
+import sys
 
 from .baseclient import BaseClient
 from .payloads import Payload
@@ -81,5 +82,7 @@ class AioPresence(BaseClient):
 
     def close(self):
         self.send_data(2, {'v': 1, 'client_id': self.client_id})
-        self.sock_writer.close()
         self.loop.close()
+        self.sock_writer.close()
+        if sys.platform == 'win32' or sys.platform == 'win64':
+            self.sock_writer._call_connection_lost(None)

--- a/pypresence/presence.py
+++ b/pypresence/presence.py
@@ -45,8 +45,10 @@ class Presence(BaseClient):
 
     def close(self):
         self.send_data(2, {'v': 1, 'client_id': self.client_id})
-        self.sock_writer.close()
         self.loop.close()
+        self.sock_writer.close()
+        if sys.platform == 'win32' or sys.platform == 'win64':
+            self.sock_writer._call_connection_lost(None)
 
 
 class AioPresence(BaseClient):

--- a/pypresence/utils.py
+++ b/pypresence/utils.py
@@ -23,12 +23,8 @@ def remove_none(d: dict):
 
 def test_ipc_path(path):
     '''Tests an IPC pipe to ensure that it actually works'''
-    try:
-        with open(path):
-            return True
-    except Exception:
-        return False
-
+    with open(path):
+        return True
 
 # Returns on first IPC pipe matching Discord's
 def get_ipc_path(pipe=None):

--- a/pypresence/utils.py
+++ b/pypresence/utils.py
@@ -26,6 +26,7 @@ def test_ipc_path(path):
     with open(path):
         return True
 
+
 # Returns on first IPC pipe matching Discord's
 def get_ipc_path(pipe=None):
     ipc = 'discord-ipc-'

--- a/pypresence/utils.py
+++ b/pypresence/utils.py
@@ -21,6 +21,15 @@ def remove_none(d: dict):
     return d
 
 
+def test_ipc_path(path):
+    '''Tests an IPC pipe to ensure that it actually works'''
+    try:
+        with open(path):
+            return True
+    except Exception:
+        return False
+
+
 # Returns on first IPC pipe matching Discord's
 def get_ipc_path(pipe=None):
     ipc = 'discord-ipc-'
@@ -40,7 +49,7 @@ def get_ipc_path(pipe=None):
         full_path = os.path.abspath(os.path.join(tempdir, path))
         if sys.platform == 'win32' or os.path.isdir(full_path):
             for entry in os.scandir(full_path):
-                if entry.name.startswith(ipc) and os.path.exists(entry):
+                if entry.name.startswith(ipc) and os.path.exists(entry) and test_ipc_path(entry):
                     return entry.path
 
 


### PR DESCRIPTION
It includes this pull request too: https://github.com/qwertyquerty/pypresence/pull/234

Under Windows, the socket is not closed and cleaned up properly for some reason. So we have to force it. This pull request fixes the problem completely.

Here is the POC:
```python
import gc
from pypresence import Presence

rpc = Presence(client_id="1193490043612971030")
rpc.connect()
rpc.close()
rpc = None
gc.collect()
```
And here is the error:
```
Exception ignored in: <function _ProactorBasePipeTransport.__del__ at 0x000001A7FAAEF160>
Traceback (most recent call last):
  File "C:\Users\joria\anaconda3\lib\asyncio\proactor_events.py", line 115, in __del__
    _warn(f"unclosed transport {self!r}", ResourceWarning, source=self)
  File "C:\Users\joria\anaconda3\lib\asyncio\proactor_events.py", line 79, in __repr__
    info.append(f'fd={self._sock.fileno()}')
  File "C:\Users\joria\anaconda3\lib\asyncio\windows_utils.py", line 102, in fileno   
    raise ValueError("I/O operation on closed pipe")
ValueError: I/O operation on closed pipe
```

This guy helped me a lot: @JorianWoltjer