### PR TITLE
Fix bug on baseclient.py

### DIFF
--- a/pypresence/baseclient.py
+++ b/pypresence/baseclient.py
@@ -52,7 +52,7 @@ class BaseClient:
             else:
                 err_handler = self._err_handle
 
-            loop.set_exception_handler(err_handler)
+            self.loop.set_exception_handler(err_handler)
             self.handler = handler
 
         if getattr(self, "on_event", None):  # Tasty bad code ;^)


### PR DESCRIPTION
Line 55 says:
>`loop.set_exception_handler(err_handler)`

If `loop` is None and `handler` is not None when the class constructor is called, then:
1. `loop` remains `None` at line 55, and we will get an AttributeError saying that NoneType has no attribute set_exception_handler.
2. `self.loop` will be updated when `update_event_loop` method is invoked at line 31.

So, we should use `self.loop` or assign `self.loop` to `loop` before using it.

