### PR TITLE
Add ActivityType Support

### DIFF
--- a/examples/rich-presence-music.py
+++ b/examples/rich-presence-music.py
@@ -1,0 +1,18 @@
+from pypresence import Presence, ActivityType
+import time
+
+client_id = '717091213148160041'  # Fake ID, put your real one here
+RPC = Presence(client_id)  # Initialize the client class
+RPC.connect() # Start the handshake loop
+
+RPC.update(
+    activity_type = ActivityType.LISTENING, # Set the activity to listening
+    details=input("Your favorite song: "),
+    state=input("The artist who made it: "),
+    end=int(input("The length of the song (in seconds): ")) + time.time(),
+    # At time of writing this, timestamps don't show for listening statuses!
+    # ...so this field is pointless lol
+) # Get the user's favorite song!
+
+while True:  # The presence will stay on as long as the program is running
+    time.sleep(15) # Can only update rich presence every 15 seconds

--- a/pypresence/__init__.py
+++ b/pypresence/__init__.py
@@ -7,6 +7,7 @@ By: qwertyquerty and LewdNeko
 from .baseclient import BaseClient
 from .client import Client, AioClient
 from .exceptions import *
+from .types import ActivityType
 from .presence import Presence, AioPresence
 
 

--- a/pypresence/client.py
+++ b/pypresence/client.py
@@ -8,6 +8,7 @@ from typing import List
 from .baseclient import BaseClient
 from .exceptions import *
 from .payloads import Payload
+from .types import ActivityType
 
 
 class Client(BaseClient):
@@ -121,6 +122,7 @@ class Client(BaseClient):
         return self.loop.run_until_complete(self.read_output())
 
     def set_activity(self, pid: int = os.getpid(),
+                     activity_type: ActivityType = None,
                      state: str = None, details: str = None,
                      start: int = None, end: int = None,
                      large_image: str = None, large_text: str = None,
@@ -129,8 +131,8 @@ class Client(BaseClient):
                      join: str = None, spectate: str = None,
                      match: str = None, buttons: list = None,
                      instance: bool = True):
-        payload = Payload.set_activity(pid=pid, state=state, details=details, start=start, end=end,
-                                       large_image=large_image, large_text=large_text, small_image=small_image,
+        payload = Payload.set_activity(pid=pid, activity_type=activity_type, state=state, details=details, start=start,
+                                       end=end, large_image=large_image, large_text=large_text, small_image=small_image,
                                        small_text=small_text, party_id=party_id, party_size=party_size, join=join,
                                        spectate=spectate, match=match, buttons=buttons, instance=instance,
                                        activity=True)
@@ -305,6 +307,7 @@ class AioClient(BaseClient):
         return await self.read_output()
 
     async def set_activity(self, pid: int = os.getpid(),
+                           activity_type: ActivityType = None,
                            state: str = None, details: str = None,
                            start: int = None, end: int = None,
                            large_image: str = None, large_text: str = None,
@@ -313,9 +316,9 @@ class AioClient(BaseClient):
                            join: str = None, spectate: str = None,
                            buttons: list = None,
                            match: str = None, instance: bool = True):
-        payload = Payload.set_activity(pid, state, details, start, end, large_image, large_text,
-                                       small_image, small_text, party_id, party_size, join, spectate,
-                                       match, buttons, instance, activity=True)
+        payload = Payload.set_activity(pid, activity_type, state, details, start, end, large_image,
+                                       large_text, small_image, small_text, party_id, party_size,
+                                       join, spectate, match, buttons, instance, activity=True)
         self.send_data(1, payload)
         return await self.read_output()
 

--- a/pypresence/payloads.py
+++ b/pypresence/payloads.py
@@ -4,6 +4,7 @@ import time
 from typing import List, Union
 
 from .utils import remove_none
+from .types import ActivityType
 
 
 class Payload:
@@ -22,6 +23,7 @@ class Payload:
 
     @classmethod
     def set_activity(cls, pid: int = os.getpid(),
+                     activity_type: ActivityType = None,
                      state: str = None, details: str = None,
                      start: int = None, end: int = None,
                      large_image: str = None, large_text: str = None,
@@ -38,12 +40,18 @@ class Payload:
             start = int(start)
         if end:
             end = int(end)
+        if activity_type:
+            if isinstance(activity_type, ActivityType):
+                activity_type = activity_type.value
+            else:
+                activity_type = int(activity_type)
 
         if activity is None:
             act_details = None
             clear = True
         else:
             act_details = {
+                    "type": activity_type,
                     "state": state,
                     "details": details,
                     "timestamps": {

--- a/pypresence/presence.py
+++ b/pypresence/presence.py
@@ -6,6 +6,7 @@ import sys
 from .baseclient import BaseClient
 from .payloads import Payload
 from .utils import remove_none, get_event_loop
+from .types import ActivityType
 
 
 class Presence(BaseClient):
@@ -14,6 +15,7 @@ class Presence(BaseClient):
         super().__init__(*args, **kwargs)
 
     def update(self, pid: int = os.getpid(),
+               activity_type: ActivityType = None,
                state: str = None, details: str = None,
                start: int = None, end: int = None,
                large_image: str = None, large_text: str = None,
@@ -24,8 +26,8 @@ class Presence(BaseClient):
                instance: bool = True, payload_override: dict = None):
 
         if payload_override is None:
-            payload = Payload.set_activity(pid=pid, state=state, details=details, start=start, end=end,
-                                           large_image=large_image, large_text=large_text,
+            payload = Payload.set_activity(pid=pid, activity_type=activity_type, state=state, details=details,
+                                           start=start, end=end, large_image=large_image, large_text=large_text,
                                            small_image=small_image, small_text=small_text, party_id=party_id,
                                            party_size=party_size, join=join, spectate=spectate,
                                            match=match, buttons=buttons, instance=instance, activity=True)
@@ -56,6 +58,7 @@ class AioPresence(BaseClient):
         super().__init__(*args, **kwargs, isasync=True)
 
     async def update(self, pid: int = os.getpid(),
+                     activity_type: ActivityType = None,
                      state: str = None, details: str = None,
                      start: int = None, end: int = None,
                      large_image: str = None, large_text: str = None,
@@ -64,8 +67,8 @@ class AioPresence(BaseClient):
                      join: str = None, spectate: str = None,
                      match: str = None, buttons: list = None,
                      instance: bool = True):
-        payload = Payload.set_activity(pid=pid, state=state, details=details, start=start, end=end,
-                                       large_image=large_image, large_text=large_text,
+        payload = Payload.set_activity(pid=pid, activity_type=activity_type, state=state, details=details,
+                                       start=start, end=end, large_image=large_image, large_text=large_text,
                                        small_image=small_image, small_text=small_text, party_id=party_id,
                                        party_size=party_size, join=join, spectate=spectate,
                                        match=match, buttons=buttons, instance=instance, activity=True)

--- a/pypresence/types.py
+++ b/pypresence/types.py
@@ -1,0 +1,11 @@
+import enum
+
+# https://discord.com/developers/docs/game-sdk/activities#data-models-activitytype-enum
+# ""type" must be one of 0, 2, 3, 5" -- Discord only implemented these four
+class ActivityType(enum.Enum):
+    PLAYING = 0
+    #STREAMING = 1
+    LISTENING = 2
+    WATCHING = 3
+    #CUSTOM = 4
+    COMPETING = 5

--- a/pypresence/types.py
+++ b/pypresence/types.py
@@ -1,11 +1,15 @@
 import enum
 
-# https://discord.com/developers/docs/game-sdk/activities#data-models-activitytype-enum
-# ""type" must be one of 0, 2, 3, 5" -- Discord only implemented these four
+
 class ActivityType(enum.Enum):
+    """
+    https://discord.com/developers/docs/game-sdk/activities#data-models-activitytype-enum
+    "type" must be one of 0, 2, 3, 5 -- Discord only implemented these four
+    """
+
     PLAYING = 0
-    #STREAMING = 1
+    # STREAMING = 1
     LISTENING = 2
     WATCHING = 3
-    #CUSTOM = 4
+    # CUSTOM = 4
     COMPETING = 5


### PR DESCRIPTION
# ActivityType Support
## What Happened?
Discord has [recently implemented support](https://github.com/discord/discord-api-docs/pull/7033) for the ActivityType field [(documented here)](https://discord.com/developers/docs/game-sdk/activities#data-models-activitytype-enum). This allows for users to set their own activity status (through RPC libraries like pypresence) to one of four activity types:
- `ActivityType.PLAYING` *(default)*
- `ActivityType.LISTENING`
- `ActivityType.WATCHING`
- `ActivityType.COMPETING`

The other activity types have not been supported in this most recent update.

## What did I do?
I added support for this field to the repository as an enum.Enum in a new `types.py` file (since I couldn't find a better place to put it, honestly).

**I tried my best to make this change as non-intrusive as possible.**

Additionally, I added a new example in the `examples/` folder to showcase the use of this field in a program.

I tested this with the example program and an additional few projects of mine somewhat-extensively and have encountered no issues. If I have missed something, please do notify me and I'll make the changes posthaste.