### PR TITLE
Added an extra path to search discord sockets

### DIFF
--- a/pypresence/utils.py
+++ b/pypresence/utils.py
@@ -37,7 +37,7 @@ def get_ipc_path(pipe=None):
 
     if sys.platform in ('linux', 'darwin'):
         tempdir = os.environ.get('XDG_RUNTIME_DIR') or (f"/run/user/{os.getuid()}" if os.path.exists(f"/run/user/{os.getuid()}") else tempfile.gettempdir())
-        paths = ['.', 'snap.discord', 'app/com.discordapp.Discord', 'app/com.discordapp.DiscordCanary']
+        paths = ['.', '..', 'snap.discord', 'app/com.discordapp.Discord', 'app/com.discordapp.DiscordCanary']
     elif sys.platform == 'win32':
         tempdir = r'\\?\pipe'
         paths = ['.']


### PR DESCRIPTION
## Issue
After calling 
```python
rpc = Presence(DISCORD_CLIENT_ID)
rpc.connect()
```

despite having Discord running, the `DiscordNotFound` error was raised during `handshake`. I was also able to identify an active socket from Rich Presence. I believe the original version failed to find the Discord socket on my MacBook.

**Operating system and Python version**: M2 MacBook Air, macOS Sequoia Version 15.5, Python 3.12.2

## Analysis
Not sure what caused this — probably something related to the environment variables `'TMPDIR'`, `'TEMP'`, or `'TMP'`, which may differ across systems.

After executing the `get_ipc_path` function in `utils.py`, `tempdir` ended up being:

```
/var/folders/2w/8nb8998n2h38fndcsz3s5wq80000gn/T/com.apple.shortcuts.mac-helper
```

instead of:

```
/var/folders/2w/8nb8998n2h38fndcsz3s5wq80000gn/T/
```

which is where the socket actually is.

## Fix
I therefore added the parent folder to the list of `paths` (line 40 of `utils.py`) as another possible location to search for the Discord socket.

## Tests
I was only able to test this code on my computer, and it fixes the issue. I believe it's a minor fix that is harmless on other systems.
