### PR TITLE
fix(presence): prevent falsy zero discard for ActivityType.PLAYING and StatusDisplayType.NAME

### DIFF
--- a/pypresence/client.py
+++ b/pypresence/client.py
@@ -177,9 +177,13 @@ class Client(BaseClient):
         if payload_override is None:
             payload = Payload.set_activity(
                 pid=pid,
-                activity_type=activity_type.value if activity_type else None,
+                activity_type=(
+                    activity_type.value if activity_type is not None else None
+                ),
                 status_display_type=(
-                    status_display_type.value if status_display_type else None
+                    status_display_type.value
+                    if status_display_type is not None
+                    else None
                 ),
                 state=state,
                 state_url=state_url,
@@ -434,9 +438,9 @@ class AioClient(BaseClient):
     ) -> dict:
         payload = Payload.set_activity(
             pid=pid,
-            activity_type=activity_type.value if activity_type else None,
+            activity_type=(activity_type.value if activity_type is not None else None),
             status_display_type=(
-                status_display_type.value if status_display_type else None
+                status_display_type.value if status_display_type is not None else None
             ),
             state=state,
             details=details,

--- a/pypresence/presence.py
+++ b/pypresence/presence.py
@@ -46,9 +46,13 @@ class Presence(BaseClient):
         if payload_override is None:
             payload = Payload.set_activity(
                 pid=pid,
-                activity_type=activity_type.value if activity_type else None,
+                activity_type=(
+                    activity_type.value if activity_type is not None else None
+                ),
                 status_display_type=(
-                    status_display_type.value if status_display_type else None
+                    status_display_type.value
+                    if status_display_type is not None
+                    else None
                 ),
                 state=state,
                 state_url=state_url,

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from pypresence import AioPresence, Presence
-from pypresence.types import ActivityType
+from pypresence.types import ActivityType, StatusDisplayType
 
 
 class TestPresenceInit:
@@ -84,6 +84,51 @@ class TestPresenceUpdate:
         payload = json.loads(payload_json)
 
         assert payload["args"]["activity"]["type"] == ActivityType.LISTENING.value
+
+    @patch("pypresence.baseclient.BaseClient.read_output")
+    def test_update_with_activity_type_playing_zero(self, mock_read_output, client_id):
+        """Test that ActivityType.PLAYING (value 0) is not discarded as falsy."""
+        presence = Presence(client_id)
+        presence.sock_writer = Mock()
+
+        async def mock_coro():
+            return {}
+
+        mock_read_output.return_value = mock_coro()
+
+        presence.update(activity_type=ActivityType.PLAYING)
+
+        call_args = presence.sock_writer.write.call_args[0][0]
+        op, length = struct.unpack("<II", call_args[:8])
+        payload_json = call_args[8 : 8 + length].decode("utf-8")
+        payload = json.loads(payload_json)
+
+        assert payload["args"]["activity"]["type"] == ActivityType.PLAYING.value
+
+    @patch("pypresence.baseclient.BaseClient.read_output")
+    def test_update_with_status_display_type_name_zero(
+        self, mock_read_output, client_id
+    ):
+        """Test that StatusDisplayType.NAME (value 0) is not discarded as falsy."""
+        presence = Presence(client_id)
+        presence.sock_writer = Mock()
+
+        async def mock_coro():
+            return {}
+
+        mock_read_output.return_value = mock_coro()
+
+        presence.update(status_display_type=StatusDisplayType.NAME)
+
+        call_args = presence.sock_writer.write.call_args[0][0]
+        op, length = struct.unpack("<II", call_args[:8])
+        payload_json = call_args[8 : 8 + length].decode("utf-8")
+        payload = json.loads(payload_json)
+
+        assert (
+            payload["args"]["activity"]["status_display_type"]
+            == StatusDisplayType.NAME.value
+        )
 
     @patch("pypresence.baseclient.BaseClient.read_output")
     def test_update_with_name(self, mock_read_output, client_id):


### PR DESCRIPTION
### Description

PR #269 migrated `ActivityType` and `StatusDisplayType` to `enum.IntEnum`.

Because `ActivityType.PLAYING` (0) and `StatusDisplayType.NAME` (0) evaluate to `False` in boolean contexts (`bool(0) == False`), ternary guards in `presence.py` and `client.py` (`activity_type.value if activity_type else None`) silently discarded both valid 0-values to `None`.

### Fix

- Changed ternary conditions in `pypresence/presence.py` and `pypresence/client.py` from `if x` to `if x is not None`.
- Added unit tests in `tests/test_presence.py` asserting that passing `ActivityType.PLAYING` and `StatusDisplayType.NAME` preserves their integer value (`0`) in the payload.

### Verification

Ran test and lint suites locally per DEVELOPMENT.md:
- `pytest` -> 102 passed, 1 skipped
- `black --check .` -> All clean
- `isort --check-only .` -> All clean
- `flake8 pypresence tests` -> All clean
- `mypy pypresence` -> Success: no issues found in 8 source files